### PR TITLE
bug fix: array copy error

### DIFF
--- a/ES6_Sorting/lib/sorting.js
+++ b/ES6_Sorting/lib/sorting.js
@@ -1,4 +1,11 @@
+/*
+first es6 test
+just some basic sorting algorithm
+*/
+
 "use strict";
+
+//test data
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -8,12 +15,6 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-/*
-first es6 test
-just some basic sorting algorithm
-*/
-
-//test data
 var TEST_DATA = [13, 3, 9, 55, 213, 34, 8, 1];
 
 //Super Sort
@@ -58,8 +59,8 @@ var Bubble = function (_Sort) {
   _createClass(Bubble, [{
     key: "sort",
     value: function sort() {
-      for (var i = 0; i < this.length - 1; i++) {
-        for (var j = 0; j < this.length - 1 - i; j++) {
+      for (var i = this.length - 1; i >= 0; i--) {
+        for (var j = 0; j < i; j++) {
           if (this.arr[j] > this.arr[j + 1]) {
             this.swap(j, j + 1);
           }
@@ -71,8 +72,44 @@ var Bubble = function (_Sort) {
   return Bubble;
 }(Sort);
 
-var bubble = new Bubble(TEST_DATA);
+//Selection Sort
 
+
+var Selection = function (_Sort2) {
+  _inherits(Selection, _Sort2);
+
+  function Selection(arr) {
+    _classCallCheck(this, Selection);
+
+    return _possibleConstructorReturn(this, (Selection.__proto__ || Object.getPrototypeOf(Selection)).call(this, arr));
+  }
+
+  _createClass(Selection, [{
+    key: "sort",
+    value: function sort() {
+      for (var i = 0; i < this.length - 1; i++) {
+        var min = i;
+        for (var j = i + 1; j < this.length; j++) {
+          if (this.arr[min] > this.arr[j]) {
+            min = j;
+          }
+        }
+        this.swap(min, i);
+      }
+    }
+  }]);
+
+  return Selection;
+}(Sort);
+
+//begin testing
+
+var bubble = new Bubble(TEST_DATA);
 bubble.log();
 bubble.sort();
 bubble.log();
+
+var selection = new Selection(TEST_DATA);
+selection.log();
+selection.sort();
+selection.log();

--- a/ES6_Sorting/lib/sorting.js
+++ b/ES6_Sorting/lib/sorting.js
@@ -23,7 +23,8 @@ var Sort = function () {
   function Sort(arr) {
     _classCallCheck(this, Sort);
 
-    this.arr = arr;
+    console.log("here comes the arr:", arr);
+    this.arr = arr.slice(0); //bug fixed!!!
     this.length = arr.length;
   }
 
@@ -53,6 +54,7 @@ var Bubble = function (_Sort) {
   function Bubble(arr) {
     _classCallCheck(this, Bubble);
 
+    console.log("bubble begin:", arr);
     return _possibleConstructorReturn(this, (Bubble.__proto__ || Object.getPrototypeOf(Bubble)).call(this, arr));
   }
 
@@ -81,6 +83,7 @@ var Selection = function (_Sort2) {
   function Selection(arr) {
     _classCallCheck(this, Selection);
 
+    console.log("selection begin:", arr);
     return _possibleConstructorReturn(this, (Selection.__proto__ || Object.getPrototypeOf(Selection)).call(this, arr));
   }
 

--- a/ES6_Sorting/lib/sorting.js
+++ b/ES6_Sorting/lib/sorting.js
@@ -23,8 +23,9 @@ var Sort = function () {
   function Sort(arr) {
     _classCallCheck(this, Sort);
 
-    console.log("here comes the arr:", arr);
-    this.arr = arr.slice(0); //bug fixed!!!
+    //slice(): copy array data
+    //copy: copy only the reference
+    this.arr = arr.slice(0);
     this.length = arr.length;
   }
 
@@ -54,7 +55,6 @@ var Bubble = function (_Sort) {
   function Bubble(arr) {
     _classCallCheck(this, Bubble);
 
-    console.log("bubble begin:", arr);
     return _possibleConstructorReturn(this, (Bubble.__proto__ || Object.getPrototypeOf(Bubble)).call(this, arr));
   }
 
@@ -83,7 +83,6 @@ var Selection = function (_Sort2) {
   function Selection(arr) {
     _classCallCheck(this, Selection);
 
-    console.log("selection begin:", arr);
     return _possibleConstructorReturn(this, (Selection.__proto__ || Object.getPrototypeOf(Selection)).call(this, arr));
   }
 

--- a/ES6_Sorting/src/sorting.es6
+++ b/ES6_Sorting/src/sorting.es6
@@ -11,8 +11,9 @@ const TEST_DATA = [13, 3, 9, 55, 213, 34, 8, 1];
 //Super Sort
 class Sort {
   constructor(arr) {
-    console.log("here comes the arr:", arr);
-    this.arr = arr.slice(0); //bug fixed!!!
+    //slice(): copy array data
+    //copy: copy only the reference
+    this.arr = arr.slice(0);
     this.length = arr.length;
   }
   swap(a, b) {
@@ -28,7 +29,6 @@ class Sort {
 //Bubble Sort
 class Bubble extends Sort {
   constructor(arr) {
-    console.log("bubble begin:", arr);
     super(arr);
   }
   sort() {
@@ -45,7 +45,6 @@ class Bubble extends Sort {
 //Selection Sort
 class Selection extends Sort {
   constructor(arr) {
-    console.log("selection begin:", arr);
     super(arr);
   }
   sort() {

--- a/ES6_Sorting/src/sorting.es6
+++ b/ES6_Sorting/src/sorting.es6
@@ -3,6 +3,8 @@ first es6 test
 just some basic sorting algorithm
 */
 
+"use strict";
+
 //test data
 const TEST_DATA = [13, 3, 9, 55, 213, 34, 8, 1];
 
@@ -28,8 +30,8 @@ class Bubble extends Sort {
     super(arr);
   }
   sort() {
-    for(let i = 0; i < this.length - 1; i++) {
-      for(let j = 0; j < this.length - 1 - i; j++) {
+    for(let i = this.length - 1; i >= 0; i--) {
+      for(let j = 0; j < i; j++) {
         if(this.arr[j] > this.arr[j + 1]) {
           this.swap(j, j + 1);
         }
@@ -38,8 +40,33 @@ class Bubble extends Sort {
   }
 }
 
-const bubble = new Bubble(TEST_DATA);
+//Selection Sort
+class Selection extends Sort {
+  constructor(arr) {
+    super(arr);
+  }
+  sort() {
+    for(let i = 0; i < this.length - 1; i++) {
+      let min = i;
+      for(let j = i + 1; j < this.length; j++) {
+        if(this.arr[min] > this.arr[j]) {
+          min = j;
+        }
+      }
+      this.swap(min, i);
+    }
+  }
+}
 
+//begin testing
+
+const bubble = new Bubble(TEST_DATA);
 bubble.log();
 bubble.sort();
 bubble.log();
+
+
+const selection = new Selection(TEST_DATA);
+selection.log();
+selection.sort();
+selection.log();

--- a/ES6_Sorting/src/sorting.es6
+++ b/ES6_Sorting/src/sorting.es6
@@ -11,7 +11,8 @@ const TEST_DATA = [13, 3, 9, 55, 213, 34, 8, 1];
 //Super Sort
 class Sort {
   constructor(arr) {
-    this.arr = arr;
+    console.log("here comes the arr:", arr);
+    this.arr = arr.slice(0); //bug fixed!!!
     this.length = arr.length;
   }
   swap(a, b) {
@@ -27,6 +28,7 @@ class Sort {
 //Bubble Sort
 class Bubble extends Sort {
   constructor(arr) {
+    console.log("bubble begin:", arr);
     super(arr);
   }
   sort() {
@@ -43,6 +45,7 @@ class Bubble extends Sort {
 //Selection Sort
 class Selection extends Sort {
   constructor(arr) {
+    console.log("selection begin:", arr);
     super(arr);
   }
   sort() {


### PR DESCRIPTION
must use ‘array.slice()’ to copy arrays
‘a = b’ only copy the reference!